### PR TITLE
feat(migrationFirebase):  add fetchImage method for image storage

### DIFF
--- a/XpeApp/XpeApp.xcodeproj/project.pbxproj
+++ b/XpeApp/XpeApp.xcodeproj/project.pbxproj
@@ -1031,7 +1031,7 @@
 				CODE_SIGN_ENTITLEMENTS = XpeApp/XpeApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_ASSET_PATHS = "\"XpeApp/Preview Content\"";
 				DEVELOPMENT_TEAM = S97GY8T7R8;
 				ENABLE_PREVIEWS = YES;
@@ -1047,7 +1047,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.xpeho.xpeapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1065,7 +1065,7 @@
 				CODE_SIGN_ENTITLEMENTS = XpeApp/XpeApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_ASSET_PATHS = "\"XpeApp/Preview Content\"";
 				DEVELOPMENT_TEAM = S97GY8T7R8;
 				ENABLE_PREVIEWS = YES;
@@ -1081,7 +1081,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.xpeho.xpeapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/XpeApp/XpeApp/Data/DataSource/WordpressAPI.swift
+++ b/XpeApp/XpeApp/Data/DataSource/WordpressAPI.swift
@@ -413,6 +413,24 @@ class WordpressAPI: WordpressAPIProtocol {
             return nil
         }
     }
+
+    // Image Storage
+
+    func fetchImage(previewPath: String) async -> Data? {
+        if let (data, statusCode) = await fetchWordpressAPI(
+            endpoint: "xpeho/v1/image-storage/\(previewPath)",
+            method: .get,
+            headers: [:]
+        ) {
+            if statusCode == 403 {
+                debugPrint("Unauthorized access in fetchImage")
+                return nil
+            }
+            return data
+        } else {
+            return nil
+        }
+    }
     
 
 }

--- a/XpeApp/XpeApp/Presentation/ViewModel/HomePageViewModel.swift
+++ b/XpeApp/XpeApp/Presentation/ViewModel/HomePageViewModel.swift
@@ -37,31 +37,20 @@ import SwiftUI
         }
     }
     
+    
     private func initLastNewsletterPreview() {
-        Task{
-            NewsletterRepositoryImpl.instance.getNewsletterPreviewUrl(
-                newsletter: self.lastNewsletter
-            ) { obtainedPreviewUrl in
-                if let previewUrl = obtainedPreviewUrl,
-                    let url = URL(string: previewUrl) {
-                    let urlSession = URLSession.shared
-                    let dataTask = urlSession.dataTask(with: url) { data, response, error in
-                        if let error = error {
-                            debugPrint("Failed to load image data: \(error.localizedDescription)")
-                            return
-                        }
-                        if let data = data, let image = UIImage(data: data) {
-                            DispatchQueue.main.async {
-                                self.lastNewsletterPreview = image
-                            }
-                        } else {
-                            debugPrint("Failed to load image for last newsletter")
-                        }
-                    }
-                    dataTask.resume()
-                } else {
-                    debugPrint("Failed to load image for last newsletter")
+        Task {
+            guard let previewPath = self.lastNewsletter?.previewPath, !previewPath.isEmpty else {
+                debugPrint("No previewPath for last newsletter")
+                return
+            }
+            if let imageData = await WordpressAPI.instance.fetchImage(previewPath: previewPath),
+               let image = UIImage(data: imageData) {
+                DispatchQueue.main.async {
+                    self.lastNewsletterPreview = image
                 }
+            } else {
+                debugPrint("Failed to load image for last newsletter with previewPath: \(self.lastNewsletter?.previewPath ?? "nil")")
             }
         }
     }


### PR DESCRIPTION
# New change proposal

Thank you for contributing to XpeApp IOS

# Change category

- [X] Feature

# Description

This pull request introduces a new API method for fetching images, updates the logic for loading the last newsletter's preview image to use this new method, and bumps the app's version numbers in the project configuration. The most significant changes are summarized below:

**Feature: Image Fetching Improvements**
* Added a new asynchronous method `fetchImage(previewPath:)` to `WordpressAPI` for retrieving images from the backend, with error handling for unauthorized access.
* Refactored `HomePageViewModel` to use the new `fetchImage` method for loading the last newsletter's preview image, simplifying the logic and improving error reporting.

# Screenshots (if any)

<img width="381" height="431" alt="image" src="https://github.com/user-attachments/assets/54707e3d-c827-4d07-8a47-40d8f2aa6620" />

# Checklist

- [X] I have tested my changes
- [X] The previous tests still works
- [X] I did not broke anything to ensure reverse compatibility
- [ ] README updated
