### PR TITLE
feat(multipleThemesQVST): add multiple themes to a QVST

### DIFF
--- a/XpeApp/XpeApp/Data/Model/Qvst/QvstCampaignModel.swift
+++ b/XpeApp/XpeApp/Data/Model/Qvst/QvstCampaignModel.swift
@@ -10,7 +10,7 @@ import Foundation
 struct QvstCampaignModel: Codable, Identifiable {
     let id: String
     let name: String
-    let theme: QvstThemeModel
+    let themes: [QvstThemeModel]
     let status: String
     let startDate: Date
     let endDate: Date
@@ -20,7 +20,7 @@ struct QvstCampaignModel: Codable, Identifiable {
     enum CodingKeys: String, CodingKey {
         case id
         case name
-        case theme
+        case themes
         case status
         case startDate = "start_date"
         case endDate = "end_date"
@@ -28,11 +28,11 @@ struct QvstCampaignModel: Codable, Identifiable {
         case participationRate = "participation_rate"
     }
     
-    init(from decoder: any Decoder) throws {
+    init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decode(String.self, forKey: .id)
         self.name = try container.decode(String.self, forKey: .name)
-        self.theme = try container.decode(QvstThemeModel.self, forKey: .theme)
+        self.themes = try container.decode([QvstThemeModel].self, forKey: .themes)
         self.status = try container.decode(String.self, forKey: .status)
         self.participationRate = try container.decode(String.self, forKey: .participationRate)
         self.action = try container.decode(String.self, forKey: .action)
@@ -51,7 +51,7 @@ struct QvstCampaignModel: Codable, Identifiable {
 
     init(id: String, 
          name: String,
-         theme: QvstThemeModel,
+         themes: [QvstThemeModel],
          status: String,
          startDate: Date,
          endDate: Date,
@@ -60,12 +60,26 @@ struct QvstCampaignModel: Codable, Identifiable {
     ) {
         self.id = id
         self.name = name
-        self.theme = theme
+        self.themes = themes
         self.status = status
         self.startDate = startDate
         self.endDate = endDate
         self.action = action
         self.participationRate = participationRate
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(themes, forKey: .themes)
+        try container.encode(status, forKey: .status)
+        let startDateString = QvstCampaignModel.dateDatabaseFormatter.string(from: startDate)
+        let endDateString = QvstCampaignModel.dateDatabaseFormatter.string(from: endDate)
+        try container.encode(startDateString, forKey: .startDate)
+        try container.encode(endDateString, forKey: .endDate)
+        try container.encode(action, forKey: .action)
+        try container.encode(participationRate, forKey: .participationRate)
     }
     
     // Formatter for decode
@@ -76,3 +90,4 @@ struct QvstCampaignModel: Codable, Identifiable {
         return formatter
     }()
 }
+

--- a/XpeApp/XpeApp/Data/Repository/QvstRepositoryImpl.swift
+++ b/XpeApp/XpeApp/Data/Repository/QvstRepositoryImpl.swift
@@ -55,7 +55,8 @@ class QvstRepositoryImpl: QvstRepository {
                 QvstCampaignEntity(
                     id: campaign.id,
                     name: campaign.name,
-                    themeName: campaign.theme.name,
+                    themeName: campaign.themes.map { $0.name }.joined(separator: ", "),
+                    themeNames: campaign.themes.map { $0.name },
                     status: campaign.status,
                     outdated: remainingDays <= 0,
                     completed: completed,
@@ -123,3 +124,4 @@ class QvstRepositoryImpl: QvstRepository {
         )
     }
 }
+

--- a/XpeApp/XpeApp/Domain/Entity/QvstCampaignEntity.swift
+++ b/XpeApp/XpeApp/Domain/Entity/QvstCampaignEntity.swift
@@ -11,6 +11,7 @@ import Foundation
     let id: String
     let name: String
     let themeName: String
+    let themeNames: [String]
     let status: String
     let outdated: Bool
     let completed: Bool
@@ -18,10 +19,11 @@ import Foundation
     let endDate: Date
     let resultLink: String
     
-    init(id: String, name: String, themeName: String, status: String, outdated: Bool, completed: Bool, remainingDays: Int, endDate: Date, resultLink: String) {
+    init(id: String, name: String, themeName: String, themeNames: [String] = [], status: String, outdated: Bool, completed: Bool, remainingDays: Int, endDate: Date, resultLink: String) {
         self.id = id
         self.name = name
         self.themeName = themeName
+        self.themeNames = themeNames
         self.status = status
         self.outdated = outdated
         self.completed = completed

--- a/XpeApp/XpeApp/Presentation/View/Qvst/CampaignCardView.swift
+++ b/XpeApp/XpeApp/Presentation/View/Qvst/CampaignCardView.swift
@@ -73,12 +73,14 @@ struct CampaignCard: View {
     private func getTagsList(campaign: QvstCampaignEntity) -> [TagPill]{
         var result: [TagPill] = []
         // Init the tagsList depending the data that we got
-        result.append(
-            TagPill(
-                label: campaign.themeName,
-                backgroundColor: XPEHO_THEME.GREEN_DARK_COLOR
+        for name in (campaign.themeNames.isEmpty ? [campaign.themeName] : campaign.themeNames) {
+            result.append(
+                TagPill(
+                    label: name,
+                    backgroundColor: XPEHO_THEME.GREEN_DARK_COLOR
+                )
             )
-        )
+        }
         
         // If the campaign is open we indicate the days remaining
         //      If it end in less or equal than 3 days and it hasn't been completed -> the color is red
@@ -129,3 +131,4 @@ struct CampaignCard: View {
         return result
     }
 }
+

--- a/XpeApp/XpeAppTests/Repository/QvstRepositoryTests.swift
+++ b/XpeApp/XpeAppTests/Repository/QvstRepositoryTests.swift
@@ -59,7 +59,7 @@ final class QvstRepositoryTests: XCTestCase {
                 QvstCampaignModel(
                     id: "campaign_id",
                     name: "Qvst Campaign",
-                    theme: QvstThemeModel(id: "theme_id", name: "Qvst Theme"),
+                    themes: [QvstThemeModel(id: "theme_id", name: "Qvst Theme")],
                     status: "OPEN",
                     startDate: currentDate,
                     endDate: currentDatePlusOneDay,
@@ -95,7 +95,7 @@ final class QvstRepositoryTests: XCTestCase {
                 QvstCampaignModel(
                     id: "campaign_id",
                     name: "Qvst Campaign",
-                    theme: QvstThemeModel(id: "theme_id", name: "Qvst Theme"),
+                    themes: [QvstThemeModel(id: "theme_id", name: "Qvst Theme")],
                     status: "OPEN",
                     startDate: currentDate,
                     endDate: currentDatePlusOneDay,
@@ -127,7 +127,7 @@ final class QvstRepositoryTests: XCTestCase {
                 QvstCampaignModel(
                     id: "campaign_id",
                     name: "Qvst Campaign",
-                    theme: QvstThemeModel(id: "theme_id", name: "Qvst Theme"),
+                    themes: [QvstThemeModel(id: "theme_id", name: "Qvst Theme")],
                     status: "OPEN",
                     startDate: currentDate,
                     endDate: currentDatePlusOneDay,
@@ -215,7 +215,7 @@ final class QvstRepositoryTests: XCTestCase {
                 QvstCampaignModel(
                     id: "campaign_id",
                     name: "Qvst Campaign",
-                    theme: QvstThemeModel(id: "theme_id", name: "Qvst Theme"),
+                    themes: [QvstThemeModel(id: "theme_id", name: "Qvst Theme")],
                     status: "OPEN",
                     startDate: currentDate,
                     endDate: currentDatePlusOneDay,
@@ -251,7 +251,7 @@ final class QvstRepositoryTests: XCTestCase {
                 QvstCampaignModel(
                     id: "campaign_id",
                     name: "Qvst Campaign",
-                    theme: QvstThemeModel(id: "theme_id", name: "Qvst Theme"),
+                    themes: [QvstThemeModel(id: "theme_id", name: "Qvst Theme")],
                     status: "OPEN",
                     startDate: currentDate,
                     endDate: currentDatePlusOneDay,
@@ -283,7 +283,7 @@ final class QvstRepositoryTests: XCTestCase {
                 QvstCampaignModel(
                     id: "campaign_id",
                     name: "Qvst Campaign",
-                    theme: QvstThemeModel(id: "theme_id", name: "Qvst Theme"),
+                    themes: [QvstThemeModel(id: "theme_id", name: "Qvst Theme")],
                     status: "OPEN",
                     startDate: currentDate,
                     endDate: currentDatePlusOneDay,


### PR DESCRIPTION
# New change proposal

Thank you for contributing to XpeApp IOS

To allow an admin to create a QVST with multiple themes in the XpeApp app, we need to update the widget so it can display several themes.

# Change category

- [X] Feature
- [ ] Fix
- [ ] Documentation
- [ ] Chore

# Screenshots (if any)

<img width="371" height="142" alt="image" src="https://github.com/user-attachments/assets/780f4d88-a0ab-4128-80fa-0f8c10c92cb1" />

# Checklist

- [X] I have tested my changes
- [X] The previous tests still works
- [ ] I did not broke anything to ensure reverse compatibility
- [ ] README updated
